### PR TITLE
Refactor command-finding methods to use `Pattern` directly

### DIFF
--- a/api/src/main/java/net/thenextlvl/commander/CommandFinder.java
+++ b/api/src/main/java/net/thenextlvl/commander/CommandFinder.java
@@ -3,6 +3,9 @@ package net.thenextlvl.commander;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -11,12 +14,25 @@ import java.util.stream.Stream;
 @NullMarked
 public interface CommandFinder {
     /**
-     * Finds commands based on the given input.
+     * Finds and returns a set of commands that match the given pattern.
      *
-     * @param input The input used to search for commands.
-     * @return A set of strings representing the found commands.
+     * @param pattern The pattern used to search for commands.
+     * @return A set of strings representing the commands that match the pattern.
      */
-    Set<String> findCommands(String input);
+    Set<String> findCommands(Pattern pattern);
+
+    /**
+     * Filters and finds commands from the provided stream that match the given pattern.
+     *
+     * @param commands The stream of commands to be searched.
+     * @param pattern  The pattern used to filter matching commands.
+     * @return A set of strings representing the commands that match the given pattern.
+     */
+    default Set<String> findCommands(Stream<String> commands, Pattern pattern) {
+        return commands.filter(command ->
+                pattern.matcher(command).matches()
+        ).collect(Collectors.toSet());
+    }
 
     /**
      * This method finds commands based on a given input.
@@ -25,5 +41,25 @@ public interface CommandFinder {
      * @param input    The input used to search for commands.
      * @return A set of strings representing the found commands.
      */
-    Set<String> findCommands(Stream<String> commands, String input);
+    default Set<String> findCommands(Stream<String> commands, String input) {
+        try {
+            return findCommands(commands, Pattern.compile(input));
+        } catch (PatternSyntaxException e) {
+            return findCommands(commands, Pattern.compile(Pattern.quote(input)));
+        }
+    }
+
+    /**
+     * Finds commands based on the given input.
+     *
+     * @param input The input used to search for commands.
+     * @return A set of strings representing the found commands.
+     */
+    default Set<String> findCommands(String input) {
+        try {
+            return findCommands(Pattern.compile(input));
+        } catch (PatternSyntaxException e) {
+            return findCommands(Pattern.compile(Pattern.quote(input)));
+        }
+    }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperCommandFinder.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperCommandFinder.java
@@ -7,26 +7,18 @@ import org.jspecify.annotations.NullMarked;
 
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @NullMarked
 @RequiredArgsConstructor
 public class PaperCommandFinder implements CommandFinder {
     private final CommanderPlugin plugin;
 
-    public Set<String> findCommands(String input) {
+    @Override
+    public Set<String> findCommands(Pattern pattern) {
         return findCommands(plugin.getServer().getCommandMap().getKnownCommands().entrySet()
                 .stream().mapMulti((entry, consumer) -> {
                     consumer.accept(entry.getKey());
                     entry.getValue().getAliases().forEach(consumer);
-                }), input);
-    }
-
-    public Set<String> findCommands(Stream<String> commands, String input) {
-        var pattern = Pattern.compile(input.replace("*", ".*"));
-        return commands.filter(command ->
-                pattern.matcher(command).matches()
-        ).collect(Collectors.toSet());
+                }), pattern);
     }
 }

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/implementation/ProxyCommandFinder.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/implementation/ProxyCommandFinder.java
@@ -7,8 +7,6 @@ import org.jspecify.annotations.NullMarked;
 
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @NullMarked
 @RequiredArgsConstructor
@@ -16,15 +14,7 @@ public class ProxyCommandFinder implements CommandFinder {
     private final CommanderPlugin plugin;
 
     @Override
-    public Set<String> findCommands(String input) {
-        return findCommands(plugin.server().getCommandManager().getAliases().stream(), input);
-    }
-
-    @Override
-    public Set<String> findCommands(Stream<String> commands, String input) {
-        var pattern = Pattern.compile(input.replace("*", ".*"));
-        return commands.filter(command ->
-                pattern.matcher(command).matches()
-        ).collect(Collectors.toSet());
+    public Set<String> findCommands(Pattern pattern) {
+        return findCommands(plugin.server().getCommandManager().getAliases().stream(), pattern);
     }
 }


### PR DESCRIPTION
Replaced `String` input with `Pattern` to improve flexibility and reduce redundant method signatures. Updated default implementations to handle both `Pattern` and `String` inputs while ensuring backward compatibility.