### PR TITLE
Moved `save` and `reload` methods to implementation

### DIFF
--- a/api/src/main/java/net/thenextlvl/commander/CommandRegistry.java
+++ b/api/src/main/java/net/thenextlvl/commander/CommandRegistry.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.commander;
 
-import net.kyori.adventure.audience.Audience;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Set;
@@ -23,9 +22,5 @@ public interface CommandRegistry {
 
     boolean unregister(String command);
 
-    void save();
-
     void unregisterCommands();
-
-    boolean reload(Audience audience);
 }

--- a/api/src/main/java/net/thenextlvl/commander/PermissionOverride.java
+++ b/api/src/main/java/net/thenextlvl/commander/PermissionOverride.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.commander;
 
-import net.kyori.adventure.audience.Audience;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -24,9 +23,5 @@ public interface PermissionOverride {
 
     boolean reset(String command);
 
-    void save();
-
     void overridePermissions();
-
-    boolean reload(Audience audience);
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/CommanderPlugin.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/CommanderPlugin.java
@@ -6,7 +6,6 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.thenextlvl.commander.CommandFinder;
 import net.thenextlvl.commander.Commander;
-import net.thenextlvl.commander.PermissionOverride;
 import net.thenextlvl.commander.paper.command.CommanderCommand;
 import net.thenextlvl.commander.paper.implementation.PaperCommandFinder;
 import net.thenextlvl.commander.paper.implementation.PaperCommandRegistry;
@@ -80,7 +79,7 @@ public class CommanderPlugin extends JavaPlugin implements Commander {
     }
 
     @Override
-    public PermissionOverride permissionOverride() {
+    public PaperPermissionOverride permissionOverride() {
         return permissionOverride;
     }
 

--- a/paper/src/main/java/net/thenextlvl/commander/paper/CommanderPlugin.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/CommanderPlugin.java
@@ -5,7 +5,6 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.thenextlvl.commander.CommandFinder;
-import net.thenextlvl.commander.CommandRegistry;
 import net.thenextlvl.commander.Commander;
 import net.thenextlvl.commander.PermissionOverride;
 import net.thenextlvl.commander.paper.command.CommanderCommand;
@@ -76,7 +75,7 @@ public class CommanderPlugin extends JavaPlugin implements Commander {
     }
 
     @Override
-    public CommandRegistry commandRegistry() {
+    public PaperCommandRegistry commandRegistry() {
         return commandRegistry;
     }
 

--- a/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperCommandRegistry.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperCommandRegistry.java
@@ -87,7 +87,6 @@ public class PaperCommandRegistry implements CommandRegistry {
                 .toList().isEmpty();
     }
 
-    @Override
     public void save() {
         hiddenFile.save();
         unregisteredFile.save();
@@ -100,7 +99,6 @@ public class PaperCommandRegistry implements CommandRegistry {
                 .forEach(this::internalUnregister);
     }
 
-    @Override
     public boolean reload(Audience audience) {
         var hidden = reloadHidden(audience);
         var unregistered = reloadUnregistered(audience);

--- a/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperPermissionOverride.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperPermissionOverride.java
@@ -73,7 +73,6 @@ public class PaperPermissionOverride implements PermissionOverride {
                 .toList().isEmpty();
     }
 
-    @Override
     public void save() {
         overridesFile.save();
     }
@@ -83,7 +82,6 @@ public class PaperPermissionOverride implements PermissionOverride {
         overridesFile.getRoot().forEach(this::internalOverride);
     }
 
-    @Override
     public boolean reload(Audience audience) {
         var previous = overridesFile.getRoot();
         var current = overridesFile.reload();

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/CommanderPlugin.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/CommanderPlugin.java
@@ -14,7 +14,6 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.thenextlvl.commander.CommandFinder;
 import net.thenextlvl.commander.Commander;
-import net.thenextlvl.commander.PermissionOverride;
 import net.thenextlvl.commander.velocity.command.CommanderCommand;
 import net.thenextlvl.commander.velocity.implementation.ProxyCommandFinder;
 import net.thenextlvl.commander.velocity.implementation.ProxyCommandRegistry;
@@ -96,7 +95,7 @@ public class CommanderPlugin implements Commander {
     }
 
     @Override
-    public PermissionOverride permissionOverride() {
+    public ProxyPermissionOverride permissionOverride() {
         return permissionOverride;
     }
 

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/CommanderPlugin.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/CommanderPlugin.java
@@ -13,7 +13,6 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.thenextlvl.commander.CommandFinder;
-import net.thenextlvl.commander.CommandRegistry;
 import net.thenextlvl.commander.Commander;
 import net.thenextlvl.commander.PermissionOverride;
 import net.thenextlvl.commander.velocity.command.CommanderCommand;
@@ -92,7 +91,7 @@ public class CommanderPlugin implements Commander {
     }
 
     @Override
-    public CommandRegistry commandRegistry() {
+    public ProxyCommandRegistry commandRegistry() {
         return commandRegistry;
     }
 

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/implementation/ProxyCommandRegistry.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/implementation/ProxyCommandRegistry.java
@@ -85,7 +85,6 @@ public class ProxyCommandRegistry implements CommandRegistry {
                 .toList().isEmpty();
     }
 
-    @Override
     public void save() {
         hiddenFile.save();
         unregisteredFile.save();
@@ -96,7 +95,6 @@ public class ProxyCommandRegistry implements CommandRegistry {
         unregisteredCommands().forEach(this::internalUnregister);
     }
 
-    @Override
     public boolean reload(Audience audience) {
         var hidden = reloadHidden(audience);
         var unregistered = reloadUnregistered(audience);

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/implementation/ProxyPermissionOverride.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/implementation/ProxyPermissionOverride.java
@@ -73,7 +73,6 @@ public class ProxyPermissionOverride implements PermissionOverride {
                 .toList().isEmpty();
     }
 
-    @Override
     public void save() {
         overridesFile.save();
     }
@@ -84,7 +83,6 @@ public class ProxyPermissionOverride implements PermissionOverride {
         throw new UnsupportedOperationException();
     }
 
-    @Override
     public boolean reload(Audience audience) {
         var previous = overridesFile.getRoot();
         var current = overridesFile.reload();


### PR DESCRIPTION
`save` and `reload` were removed from `CommandRegistry` and `PermissionOverride` and added to the implementation classes for better separation of concerns. Adjusted references accordingly.