### PR TITLE
Added `@Unmodifiable` annotation to collections

### DIFF
--- a/api/src/main/java/net/thenextlvl/commander/CommandFinder.java
+++ b/api/src/main/java/net/thenextlvl/commander/CommandFinder.java
@@ -1,5 +1,6 @@
 package net.thenextlvl.commander;
 
+import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Set;
@@ -17,8 +18,9 @@ public interface CommandFinder {
      * Finds and returns a set of commands that match the given pattern.
      *
      * @param pattern The pattern used to search for commands.
-     * @return A set of strings representing the commands that match the pattern.
+     * @return An unmodifiable set of strings representing the commands that match the pattern.
      */
+    @Unmodifiable
     Set<String> findCommands(Pattern pattern);
 
     /**
@@ -26,9 +28,9 @@ public interface CommandFinder {
      *
      * @param commands The stream of commands to be searched.
      * @param pattern  The pattern used to filter matching commands.
-     * @return A set of strings representing the commands that match the given pattern.
+     * @return An unmodifiable set of strings representing the commands that match the given pattern.
      */
-    default Set<String> findCommands(Stream<String> commands, Pattern pattern) {
+    default @Unmodifiable Set<String> findCommands(Stream<String> commands, Pattern pattern) {
         return commands.filter(command ->
                 pattern.matcher(command).matches()
         ).collect(Collectors.toSet());
@@ -39,9 +41,9 @@ public interface CommandFinder {
      *
      * @param commands The stream of commands to search for.
      * @param input    The input used to search for commands.
-     * @return A set of strings representing the found commands.
+     * @return An unmodifiable set of strings representing the found commands.
      */
-    default Set<String> findCommands(Stream<String> commands, String input) {
+    default @Unmodifiable Set<String> findCommands(Stream<String> commands, String input) {
         try {
             return findCommands(commands, Pattern.compile(input));
         } catch (PatternSyntaxException e) {
@@ -53,9 +55,9 @@ public interface CommandFinder {
      * Finds commands based on the given input.
      *
      * @param input The input used to search for commands.
-     * @return A set of strings representing the found commands.
+     * @return An unmodifiable set of strings representing the found commands.
      */
-    default Set<String> findCommands(String input) {
+    default @Unmodifiable Set<String> findCommands(String input) {
         try {
             return findCommands(Pattern.compile(input));
         } catch (PatternSyntaxException e) {

--- a/api/src/main/java/net/thenextlvl/commander/CommandRegistry.java
+++ b/api/src/main/java/net/thenextlvl/commander/CommandRegistry.java
@@ -1,13 +1,16 @@
 package net.thenextlvl.commander;
 
+import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Set;
 
 @NullMarked
 public interface CommandRegistry {
+    @Unmodifiable
     Set<String> hiddenCommands();
 
+    @Unmodifiable
     Set<String> unregisteredCommands();
 
     boolean hide(String command);

--- a/api/src/main/java/net/thenextlvl/commander/PermissionOverride.java
+++ b/api/src/main/java/net/thenextlvl/commander/PermissionOverride.java
@@ -1,5 +1,6 @@
 package net.thenextlvl.commander;
 
+import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -7,8 +8,10 @@ import java.util.Map;
 
 @NullMarked
 public interface PermissionOverride {
+    @Unmodifiable
     Map<String, @Nullable String> originalPermissions();
 
+    @Unmodifiable
     Map<String, @Nullable String> overrides();
 
     @Nullable

--- a/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperPermissionOverride.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperPermissionOverride.java
@@ -8,6 +8,7 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.commander.PermissionOverride;
 import net.thenextlvl.commander.paper.CommanderPlugin;
+import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -31,13 +32,13 @@ public class PaperPermissionOverride implements PermissionOverride {
     }
 
     @Override
-    public Map<String, @Nullable String> overrides() {
-        return new HashMap<>(overridesFile.getRoot());
+    public @Unmodifiable Map<String, @Nullable String> originalPermissions() {
+        return Map.copyOf(originalPermissions);
     }
 
     @Override
-    public Map<String, @Nullable String> originalPermissions() {
-        return new HashMap<>(originalPermissions);
+    public @Unmodifiable Map<String, @Nullable String> overrides() {
+        return new HashMap<>(overridesFile.getRoot());
     }
 
     @Override

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/implementation/ProxyPermissionOverride.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/implementation/ProxyPermissionOverride.java
@@ -8,6 +8,7 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.commander.PermissionOverride;
 import net.thenextlvl.commander.velocity.CommanderPlugin;
+import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -30,14 +31,14 @@ public class ProxyPermissionOverride implements PermissionOverride {
     }
 
     @Override
-    public Map<String, @Nullable String> overrides() {
-        return new HashMap<>(overridesFile.getRoot());
+    @Deprecated
+    public @Unmodifiable Map<String, @Nullable String> originalPermissions() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    @Deprecated
-    public Map<String, @Nullable String> originalPermissions() throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
+    public @Unmodifiable Map<String, @Nullable String> overrides() {
+        return Map.copyOf(overridesFile.getRoot());
     }
 
     @Override


### PR DESCRIPTION
Ensured returned collections are explicitly marked as unmodifiable to enhance clarity and immutability in APIs.