### PR TITLE
feat!: Add autosave with conflict detection for command configuration

### DIFF
--- a/api/src/main/java/net/thenextlvl/commander/util/FileUtil.java
+++ b/api/src/main/java/net/thenextlvl/commander/util/FileUtil.java
@@ -1,0 +1,62 @@
+package net.thenextlvl.commander.util;
+
+import core.file.FileIO;
+import core.io.PathIO;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public final class FileUtil {
+    private static final int BUFFER_SIZE = 8192;
+
+    public static String digest(FileIO<?> file) {
+        return digest(((PathIO) file.getIO()).getPath());
+    }
+
+    public static String digest(Path path) {
+        try {
+            if (!Files.exists(path)) return "";
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            try (InputStream in = new DigestInputStream(Files.newInputStream(path), md)) {
+                byte[] buffer = new byte[BUFFER_SIZE];
+                while (in.read(buffer) != -1) {
+                    // just read to update digest
+                }
+            }
+            byte[] result = md.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte b : result) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch (IOException | NoSuchAlgorithmException e) {
+            return "";
+        }
+    }
+
+    public static FileTime lastModified(FileIO<?> file) {
+        try {
+            Path path = ((PathIO) file.getIO()).getPath();
+            if (Files.exists(path)) {
+                return Files.getLastModifiedTime(path);
+            }
+        } catch (IOException ignored) {
+        }
+        return FileTime.fromMillis(0);
+    }
+
+    public static boolean hasChanged(FileIO<?> file, String digest, FileTime lastModified) {
+        try {
+            Path path = ((PathIO) file.getIO()).getPath();
+            if (!Files.exists(path)) return false;
+            FileTime current = Files.getLastModifiedTime(path);
+            if (current.equals(lastModified)) return false;
+            return !digest(path).equals(digest);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/api/src/main/resources/commander.properties
+++ b/api/src/main/resources/commander.properties
@@ -12,5 +12,6 @@ command.reload.failed=<red><prefix> <hover:show_text:'<error>'>Failed to reloade
 command.reload.success=<gray><prefix> Successfully reloaded command files</gray>
 command.reload.changes=<gray><prefix> <green><additions></green> additions and <red><deletions></red> deletions <dark_gray>(<gold><file></gold>)</dark_gray></gray>
 command.saved=<gray><prefix> Successfully saved command files</gray>
+command.save.conflict=<gold><prefix> <yellow><b>Configuration files have been changed on disk.</b></yellow> Use <click:suggest_command:'/{ROOTCMD} reload'><aqua><u>/{ROOTCMD} reload</u></aqua></click> to reload the configuration files and discard your current changes, or <click:suggest_command:'/{ROOTCMD} save'><aqua><u>/{ROOTCMD} save</u></aqua></click> to force the current changes to be saved.</gold>
 command.unknown=<red><prefix> The command <dark_gray>(<dark_red><command></dark_red>)</dark_gray> does not exist</red>
 nothing.changed=<red><prefix> Nothing could be changed</red>

--- a/api/src/main/resources/commander_german.properties
+++ b/api/src/main/resources/commander_german.properties
@@ -12,5 +12,6 @@ command.reload.failed=<red><prefix> <hover:show_text:'<error>'>Befehlsdateien ko
 command.reload.success=<gray><prefix> Befehlsdateien wurden erfolgreich neu geladen</gray>
 command.reload.changes=<gray><prefix> <green><additions></green> hinzugefügt und <red><deletions></red> entfernt <dark_gray>(<gold><file></gold>)</dark_gray></gray>
 command.saved=<gray><prefix> Befehlsdateien wurden erfolgreich gespeichert</gray>
+command.save.conflict=<gold><prefix> <yellow><b>Die Konfigurationsdateien wurden auf der Festplatte geändert.</b></yellow> Verwende <click:suggest_command:'/{ROOTCMD} reload'><aqua><u>/{ROOTCMD} reload</u></aqua></click>, um die Konfigurationsdateien neu zu laden und deine aktuellen Änderungen zu verwerfen, oder <click:suggest_command:'/{ROOTCMD} save'><aqua><u>/{ROOTCMD} save</u></aqua></click>, um die aktuellen Änderungen zu speichern.</gold>
 command.unknown=<red><prefix> Der Befehl <dark_gray>(<dark_red><command></dark_red>)</dark_gray> existiert nicht</red>
 nothing.changed=<red><prefix> Es konnte nichts geändert werden</red>

--- a/paper/src/main/java/net/thenextlvl/commander/paper/command/HideCommand.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/command/HideCommand.java
@@ -35,7 +35,10 @@ class HideCommand {
         var success = plugin.commandRegistry().hide(command);
         var message = success ? "command.hidden" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
-        if (success) plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+        if (success) {
+            plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+            plugin.autoSave(sender);
+        }
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/command/PermissionResetCommand.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/command/PermissionResetCommand.java
@@ -39,7 +39,10 @@ class PermissionResetCommand {
                 .orElse("null");
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command),
                 Placeholder.parsed("permission", permission));
-        if (success) plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+        if (success) {
+            plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+            plugin.autoSave(sender);
+        }
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/command/PermissionSetCommand.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/command/PermissionSetCommand.java
@@ -39,7 +39,10 @@ class PermissionSetCommand {
         plugin.bundle().sendMessage(sender, message,
                 Placeholder.parsed("permission", permission),
                 Placeholder.parsed("command", command));
-        if (success) plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+        if (success) {
+            plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+            plugin.autoSave(sender);
+        }
         return com.mojang.brigadier.Command.SINGLE_SUCCESS;
     }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/command/PermissionUnsetCommand.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/command/PermissionUnsetCommand.java
@@ -28,7 +28,10 @@ class PermissionUnsetCommand {
         plugin.bundle().sendMessage(sender, message,
                 Placeholder.parsed("permission", "null"),
                 Placeholder.parsed("command", command));
-        if (success) plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+        if (success) {
+            plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+            plugin.autoSave(sender);
+        }
         return com.mojang.brigadier.Command.SINGLE_SUCCESS;
     }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/command/RegisterCommand.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/command/RegisterCommand.java
@@ -32,7 +32,10 @@ class RegisterCommand {
         var success = plugin.commandRegistry().register(command);
         var message = success ? "command.registered" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
-        if (success) plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+        if (success) {
+            plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+            plugin.autoSave(sender);
+        }
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/command/ResetCommand.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/command/ResetCommand.java
@@ -42,7 +42,10 @@ class ResetCommand {
         var s3 = plugin.commandRegistry().reveal(command);
         var message = s1 || s2 || s3 ? "command.reset" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
-        if (s1 || s2 || s3) plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+        if (s1 || s2 || s3) {
+            plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+            plugin.autoSave(sender);
+        }
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/command/RevealCommand.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/command/RevealCommand.java
@@ -33,7 +33,10 @@ class RevealCommand {
         var success = plugin.commandRegistry().reveal(command);
         var message = success ? "command.revealed" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
-        if (success) plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+        if (success) {
+            plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+            plugin.autoSave(sender);
+        }
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/command/SaveCommand.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/command/SaveCommand.java
@@ -6,19 +6,25 @@ import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import net.thenextlvl.commander.paper.CommanderPlugin;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 class SaveCommand {
     public static ArgumentBuilder<CommandSourceStack, ?> create(CommanderPlugin plugin) {
-        return Commands.literal("save").executes(context -> save(context, plugin));
+        return Commands.literal("save")
+                .executes(context -> save(context, plugin));
     }
 
     private static int save(CommandContext<CommandSourceStack> context, CommanderPlugin plugin) {
         var sender = context.getSource().getSender();
-        plugin.commandRegistry().save();
-        plugin.permissionOverride().save();
-        plugin.bundle().sendMessage(sender, "command.saved");
+        var reg = plugin.commandRegistry().save(true);
+        var perm = plugin.permissionOverride().save(true);
+        var message = reg && perm ? "command.saved" : "command.save.conflict";
+        var mm = MiniMessage.miniMessage();
+        var serialized = mm.serialize(plugin.bundle().component(message, sender));
+        serialized = serialized.replace("{ROOTCMD}", CommanderPlugin.ROOT_COMMAND);
+        sender.sendMessage(mm.deserialize(serialized));
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/command/UnregisterCommand.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/command/UnregisterCommand.java
@@ -26,7 +26,10 @@ class UnregisterCommand {
         var success = plugin.commandRegistry().unregister(command);
         var message = success ? "command.unregistered" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
-        if (success) plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+        if (success) {
+            plugin.getServer().getOnlinePlayers().forEach(Player::updateCommands);
+            plugin.autoSave(sender);
+        }
         return com.mojang.brigadier.Command.SINGLE_SUCCESS;
     }
 }

--- a/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperCommandRegistry.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperCommandRegistry.java
@@ -4,6 +4,8 @@ import com.google.gson.reflect.TypeToken;
 import core.file.FileIO;
 import core.file.format.GsonFile;
 import core.io.IO;
+import java.nio.file.attribute.FileTime;
+import net.thenextlvl.commander.util.FileUtil;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.commander.CommandRegistry;
@@ -23,6 +25,10 @@ public class PaperCommandRegistry implements CommandRegistry {
     private final FileIO<Set<String>> hiddenFile;
     private final FileIO<Set<String>> unregisteredFile;
     private final CommanderPlugin plugin;
+    private String hiddenDigest;
+    private String unregisteredDigest;
+    private FileTime hiddenLastModified;
+    private FileTime unregisteredLastModified;
 
     public PaperCommandRegistry(CommanderPlugin plugin) {
         this.hiddenFile = new GsonFile<Set<String>>(
@@ -34,6 +40,10 @@ public class PaperCommandRegistry implements CommandRegistry {
                 new HashSet<>(), new TypeToken<>() {
         }).reload().saveIfAbsent();
         this.plugin = plugin;
+        this.hiddenDigest = FileUtil.digest(hiddenFile);
+        this.unregisteredDigest = FileUtil.digest(unregisteredFile);
+        this.hiddenLastModified = FileUtil.lastModified(hiddenFile);
+        this.unregisteredLastModified = FileUtil.lastModified(unregisteredFile);
     }
 
     @Override
@@ -88,8 +98,19 @@ public class PaperCommandRegistry implements CommandRegistry {
     }
 
     public void save() {
+        save(true);
+    }
+
+    public boolean save(boolean force) {
+        if (!force && FileUtil.hasChanged(hiddenFile, hiddenDigest, hiddenLastModified)) return false;
+        if (!force && FileUtil.hasChanged(unregisteredFile, unregisteredDigest, unregisteredLastModified)) return false;
         hiddenFile.save();
         unregisteredFile.save();
+        hiddenDigest = FileUtil.digest(hiddenFile);
+        unregisteredDigest = FileUtil.digest(unregisteredFile);
+        hiddenLastModified = FileUtil.lastModified(hiddenFile);
+        unregisteredLastModified = FileUtil.lastModified(unregisteredFile);
+        return true;
     }
 
     @Override
@@ -108,6 +129,8 @@ public class PaperCommandRegistry implements CommandRegistry {
     private boolean reloadUnregistered(Audience audience) {
         var previous = unregisteredFile.getRoot();
         var current = unregisteredFile.reload();
+        unregisteredDigest = FileUtil.digest(unregisteredFile);
+        unregisteredLastModified = FileUtil.lastModified(unregisteredFile);
         if (previous.equals(current.getRoot())) return false;
         var difference = difference(previous, current.getRoot());
         var additions = difference.entrySet().stream()
@@ -126,6 +149,8 @@ public class PaperCommandRegistry implements CommandRegistry {
     private boolean reloadHidden(Audience audience) {
         var previous = hiddenFile.getRoot();
         var current = hiddenFile.reload();
+        hiddenDigest = FileUtil.digest(hiddenFile);
+        hiddenLastModified = FileUtil.lastModified(hiddenFile);
         if (previous.equals(current.getRoot())) return false;
         var difference = difference(previous, current.getRoot());
         var additions = difference.entrySet().stream()
@@ -161,4 +186,6 @@ public class PaperCommandRegistry implements CommandRegistry {
         commands.put(command, registered);
         return true;
     }
+
 }
+

--- a/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperPermissionOverride.java
+++ b/paper/src/main/java/net/thenextlvl/commander/paper/implementation/PaperPermissionOverride.java
@@ -4,6 +4,8 @@ import com.google.gson.reflect.TypeToken;
 import core.file.FileIO;
 import core.file.format.GsonFile;
 import core.io.IO;
+import java.nio.file.attribute.FileTime;
+import net.thenextlvl.commander.util.FileUtil;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.commander.PermissionOverride;
@@ -22,6 +24,8 @@ public class PaperPermissionOverride implements PermissionOverride {
     private final Map<String, @Nullable String> originalPermissions = new HashMap<>();
     private final FileIO<Map<String, @Nullable String>> overridesFile;
     private final CommanderPlugin plugin;
+    private String overridesDigest;
+    private FileTime overridesLastModified;
 
     public PaperPermissionOverride(CommanderPlugin plugin) {
         this.overridesFile = new GsonFile<Map<String, @Nullable String>>(
@@ -29,6 +33,8 @@ public class PaperPermissionOverride implements PermissionOverride {
                 new HashMap<>(), new TypeToken<>() {
         }).reload().saveIfAbsent();
         this.plugin = plugin;
+        this.overridesDigest = FileUtil.digest(overridesFile);
+        this.overridesLastModified = FileUtil.lastModified(overridesFile);
     }
 
     @Override
@@ -75,7 +81,15 @@ public class PaperPermissionOverride implements PermissionOverride {
     }
 
     public void save() {
+        save(true);
+    }
+
+    public boolean save(boolean force) {
+        if (!force && FileUtil.hasChanged(overridesFile, overridesDigest, overridesLastModified)) return false;
         overridesFile.save();
+        overridesDigest = FileUtil.digest(overridesFile);
+        overridesLastModified = FileUtil.lastModified(overridesFile);
+        return true;
     }
 
     @Override
@@ -86,6 +100,8 @@ public class PaperPermissionOverride implements PermissionOverride {
     public boolean reload(Audience audience) {
         var previous = overridesFile.getRoot();
         var current = overridesFile.reload();
+        overridesDigest = FileUtil.digest(overridesFile);
+        overridesLastModified = FileUtil.lastModified(overridesFile);
         if (previous.equals(current.getRoot())) return false;
         var difference = difference(previous, current.getRoot());
         var additions = difference.entrySet().stream()
@@ -134,4 +150,6 @@ public class PaperPermissionOverride implements PermissionOverride {
         registered.setPermission(permission);
         return Objects.equals(registered.getPermission(), permission);
     }
+
 }
+

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/command/HideCommand.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/command/HideCommand.java
@@ -33,6 +33,7 @@ class HideCommand {
         var success = plugin.commandRegistry().hide(command);
         var message = success ? "command.hidden" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
+        if (success) plugin.autoSave(sender);
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/command/PermissionResetCommand.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/command/PermissionResetCommand.java
@@ -33,6 +33,7 @@ class PermissionResetCommand {
         var message = success ? "permission.reset" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command),
                 Placeholder.parsed("permission", "null"));
+        if (success) plugin.autoSave(sender);
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/command/PermissionSetCommand.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/command/PermissionSetCommand.java
@@ -40,6 +40,7 @@ class PermissionSetCommand {
         plugin.bundle().sendMessage(sender, message,
                 Placeholder.parsed("permission", permission),
                 Placeholder.parsed("command", command));
+        if (success) plugin.autoSave(sender);
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/command/RegisterCommand.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/command/RegisterCommand.java
@@ -31,6 +31,7 @@ class RegisterCommand {
         var success = plugin.commandRegistry().register(command);
         var message = success ? "command.registered" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
+        if (success) plugin.autoSave(sender);
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/command/ResetCommand.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/command/ResetCommand.java
@@ -41,6 +41,7 @@ class ResetCommand {
         var s3 = plugin.commandRegistry().reveal(command);
         var message = s1 || s2 || s3 ? "command.reset" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
+        if (s1 || s2 || s3) plugin.autoSave(sender);
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/command/RevealCommand.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/command/RevealCommand.java
@@ -32,6 +32,7 @@ class RevealCommand {
         var success = plugin.commandRegistry().reveal(command);
         var message = success ? "command.revealed" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
+        if (success) plugin.autoSave(sender);
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/command/SaveCommand.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/command/SaveCommand.java
@@ -6,6 +6,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.CommandSource;
 import net.thenextlvl.commander.velocity.CommanderPlugin;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -17,9 +18,13 @@ class SaveCommand {
 
     private static int save(CommandContext<CommandSource> context, CommanderPlugin plugin) {
         var sender = context.getSource();
-        plugin.commandRegistry().save();
-        plugin.permissionOverride().save();
-        plugin.bundle().sendMessage(sender, "command.saved");
+        var reg = plugin.commandRegistry().save(true);
+        var perm = plugin.permissionOverride().save(true);
+        var message = reg && perm ? "command.saved" : "command.save.conflict";
+        var mm = MiniMessage.miniMessage();
+        var serialized = mm.serialize(plugin.bundle().component(message, sender));
+        serialized = serialized.replace("{ROOTCMD}", CommanderPlugin.ROOT_COMMAND);
+        sender.sendMessage(mm.deserialize(serialized));
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/velocity/src/main/java/net/thenextlvl/commander/velocity/command/UnregisterCommand.java
+++ b/velocity/src/main/java/net/thenextlvl/commander/velocity/command/UnregisterCommand.java
@@ -26,6 +26,7 @@ class UnregisterCommand {
         var success = plugin.commandRegistry().unregister(command);
         var message = success ? "command.unregistered" : "nothing.changed";
         plugin.bundle().sendMessage(sender, message, Placeholder.parsed("command", command));
+        if (success) plugin.autoSave(sender);
         return Command.SINGLE_SUCCESS;
     }
 }


### PR DESCRIPTION
- Implemented MD5-based conflict detection and autosave mechanism to prevent accidental overwrites of configuration files (`hidden`, `unregistered`, and permissions).
- Added user-friendly messaging (`command.save.conflict`) in English and German, prompting users to reload or force-save configuration files when conflicts are detected.
- Enhanced all command actions (hide, register, unregister, permission set/reset) to trigger autosave checks after changes.

BREAKING CHANGE: Configuration changes now prompt conflict messages if modified externally; manual resolution required to overwrite or reload changes.

Fixes #24 